### PR TITLE
only callback once per press, build script to fix permissions for GPIO, set current server address

### DIFF
--- a/Cabinet/Cabinet/Cabinet.cbp
+++ b/Cabinet/Cabinet/Cabinet.cbp
@@ -23,6 +23,10 @@
 					<Add library="wiringPi" />
 					<Add directory="../libCabinet/bin/Debug" />
 				</Linker>
+				<ExtraCommands>
+					<Add after="chmod +x PostBuildSteps.sh" />
+					<Add after="./PostBuildSteps.sh" />
+				</ExtraCommands>
 			</Target>
 			<Target title="Release">
 				<Option output="bin/Release/Cabinet" prefix_auto="1" extension_auto="1" />
@@ -42,6 +46,7 @@
 			<Add option="-Wall" />
 			<Add option="-fexceptions" />
 		</Compiler>
+		<Unit filename="PostBuildSteps.sh" />
 		<Unit filename="main.cpp" />
 		<Extensions>
 			<code_completion />

--- a/Cabinet/Cabinet/PostBuildSteps.sh
+++ b/Cabinet/Cabinet/PostBuildSteps.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+
+sudo chown root:root bin/Debug/Cabinet
+sudo chmod a+s bin/Debug/Cabinet

--- a/Cabinet/Cabinet/main.cpp
+++ b/Cabinet/Cabinet/main.cpp
@@ -22,7 +22,7 @@ int main()
     wiringPiSetup();
 
     std::string boxID = "1111R";
-    std::string URL = "http://servertobedecided.invalid/events";
+    std::string URL = "http://192.168.0.110/events/";
 
     LibCurlPostClient client = LibCurlPostClient();
     Postman pat(URL, &client);

--- a/Cabinet/Cabinet/main.cpp
+++ b/Cabinet/Cabinet/main.cpp
@@ -35,7 +35,6 @@ int main()
     WiringPiPin doorPin{0};
     Switch doorSwitch{&doorPin, doorEventCallback};
 
-
     while(true){
 
         doorSwitch.Service();
@@ -48,4 +47,5 @@ int main()
     }
 
     return 0;
+
 }

--- a/Cabinet/Cabinet/main.cpp
+++ b/Cabinet/Cabinet/main.cpp
@@ -32,7 +32,7 @@ int main()
 
     auto doorEventCallback = std::bind(&Cabinet::DoorEventCallback, &cabinet, _1);
 
-    WiringPiPin doorPin{0};
+    WiringPiPin doorPin{2};
     Switch doorSwitch{&doorPin, doorEventCallback};
 
     while(true){

--- a/Cabinet/libCabinet/Switch.cpp
+++ b/Cabinet/libCabinet/Switch.cpp
@@ -36,14 +36,10 @@ void Switch::StateCheck()
         }
         else
         {
-           if ((currentTime() - firstTime) >= milliseconds(10))
+           if (((currentTime() - firstTime) >= milliseconds(10)) && !PressedState)
            {
-                if(!PressedState)
-                {
-                    doorCallbackFunction(true);
-                }
+                doorCallbackFunction(true);
                 PressedState = true;
-
            }
         }
         previouslyPressed = true;

--- a/Cabinet/libCabinet/Switch.cpp
+++ b/Cabinet/libCabinet/Switch.cpp
@@ -38,8 +38,12 @@ void Switch::StateCheck()
         {
            if ((currentTime() - firstTime) >= milliseconds(10))
            {
+                if(!PressedState)
+                {
+                    doorCallbackFunction(true);
+                }
                 PressedState = true;
-                doorCallbackFunction(true);
+
            }
         }
         previouslyPressed = true;


### PR DESCRIPTION
- only callback once per press of the button
- build script to set permissions and ownership of Cabinet executable to allow GPIO input
- set server address to current local test server address

As of this commit, switch events are logged in the database.
